### PR TITLE
Update to new API changed in material-ui 0.12

### DIFF
--- a/client/components/Application.js
+++ b/client/components/Application.js
@@ -16,7 +16,7 @@ const Logout = require('./Logout');
 
 // MUI
 const mui = require('material-ui');
-const ThemeManager = new mui.Styles.ThemeManager();
+const ThemeManager = mui.Styles.ThemeManager;
 // Needed for onTouchTap
 // Can go away when react 1.0 release
 // Check this repo:
@@ -33,7 +33,7 @@ const Application = React.createClass({
 
   getChildContext() {
     return {
-      muiTheme: ThemeManager.getCurrentTheme(),
+      muiTheme: ThemeManager.getMuiTheme(),
       stores: require('./../stores'),
     };
   },


### PR DESCRIPTION
Material UI 0.12 changed the theme API. 

https://github.com/callemall/material-ui/issues/1810

This commit switched to the newer version:

https://github.com/atsid/gcal-leave-scraper/commit/80b15ae7ee8dc3797d1209a4877eb9686bd8b281#diff-b9cfc7f2cdf78a7f4b91a753d10865a2L88
